### PR TITLE
Add babel-plugin-debug-tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
  - [transform-builtin-extend](https://github.com/loganfsmyth/babel-plugin-transform-builtin-extend) - Enable extending builtin types like `Error` and `Array`, which require special treatment and require static analysis to detect.
  - [console-source](https://github.com/peteringram0/babel-plugin-console-source) - Prepends the file name and line numbers for all console commands
  - [version](https://github.com/hustcc/babel-plugin-version) - Babel plugin replace defined identifier `__VERSION__` to pkg.version.
+ - [babel-plugin-debug-tools](https://www.npmjs.com/package/babel-plugin-debug-tools) Babeljs Debug Tools helps you insert debug code and easely remove it when deploy to production
 
 ### Module Resolution
 


### PR DESCRIPTION
Add [babel-plugin-debug-tools](https://www.npmjs.com/package/babel-plugin-debug-tools) Babeljs Debug Tools helps you insert debug code and easely remove it when deploy to production