### PR TITLE
Add babel-plugin-lucide-react-native to this list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
  - [lodash](https://github.com/lodash/babel-plugin-lodash) - Cherry-picks Lodash modules so you don’t have to.
  - [ramda](https://github.com/megawac/babel-plugin-ramda) - Cherry-picks Ramda modules so you don’t have to.
+ - [lucide-react-native](https://github.com/WanQuanXie/babel-plugin-lucide-react-native) - Cherry-picks Lucide React Native modules so you don’t have to.
  - [module-resolver](https://github.com/tleunen/babel-plugin-module-resolver) - Custom module resolver.
  - [root-import](https://github.com/entwicklerstube/babel-plugin-root-import) - Import modules from the root with `require('~/foo')` syntax.
  - [webpack-alias](https://github.com/trayio/babel-plugin-webpack-alias) - Allows you to use webpack aliases and most of webpack resolve features in Babel.


### PR DESCRIPTION
**babel-plugin-lucide-react-native** plugin is a transform (like babel-plugin-ramda) to remove unused Lucide Icon dependencies in React Native, without forcing the user to cherry pick methods manually. This lets user use lucide-react-native naturally (aka as documented) without worrying about bundling parts you're not using.